### PR TITLE
Add from parameter instead of report type

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-bundle exec ruby lib/mergometer.rb $1
+bundle exec ruby lib/mergometer.rb $1 $2 $3

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -1,8 +1,8 @@
 require "facets/math"
 require "octokit"
-
 require "mergometer/version"
 require "mergometer/configuration"
+require "mergometer/report"
 
 reports_path = File.expand_path("../mergometer/reports/**/*.rb", __FILE__)
 Dir[reports_path].each { |f| require f }
@@ -11,12 +11,12 @@ module Mergometer
   Configuration.new(cache_time: 72 * 3600).apply
 
   begin
-    report_type = Object.const_get("Mergometer::Reports::#{ARGV.first}")
+    report_type = Object.const_get("Mergometer::Reports::#{ARGV[1]}")
   rescue NameError
     reports = Mergometer::Reports.constants.select { |c| c.to_s.end_with?("Report") }
     puts "Report not found, must be one of: \n\n" + reports.join("\n")
     exit
   end
 
-  report_type.new("cookpad/global-web").run
+  report_type.new(ARGV[0], from: ARGV[2]).run
 end

--- a/lib/mergometer/report.rb
+++ b/lib/mergometer/report.rb
@@ -5,8 +5,9 @@ module Mergometer
   class Report
     require "hirb"
 
-    def initialize(repo)
+    def initialize(repo, **options)
       @repo = repo
+      @from = options[:from] || (Date.today - 1.day).beginning_of_week.to_s
     end
 
     def run
@@ -16,7 +17,7 @@ module Mergometer
 
     private
 
-      attr_accessor :repo
+      attr_accessor :repo, :from
 
       def render
         puts Hirb::Helpers::AutoTable.render(
@@ -46,7 +47,7 @@ module Mergometer
       end
 
       def filter
-        "base:master repo:#{repo} type:pr is:merged"
+        "base:master #{repo} type:pr is:merged created:>=#{from}"
       end
 
       def fields_to_preload


### PR DESCRIPTION
- Takes from parameter (date from which it will fetch prs)
- Remove report type parameter
  - In line with report different reports and including them to one class

- There are a few half-assed changes, but they will be filled by later PRs :'( 

- And removed methods unrelated to PRs fetching - will be moving these to new base report branch, so that each report class only need to take prs as initialize parameter