### PR TITLE
Add from parameter 

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-bundle exec ruby lib/mergometer.rb $1 $2
+bundle exec ruby lib/mergometer.rb $1 $2 $3

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -11,11 +11,11 @@ module Mergometer
   Configuration.new(cache_time: 72 * 3600).apply
 
   begin
-    report_type = Object.const_get("Mergometer::Reports::#{ARGV[0]}")
+    report_type = Object.const_get("Mergometer::Reports::#{ARGV[1]}")
   rescue NameError
     reports = Mergometer::Reports.constants.select { |c| c.to_s.end_with?("Report") }
     puts "Report not found, must be one of: \n\n" + reports.join("\n")
     exit
   end
-  report_type.new(ARGV[1]).run
+  report_type.new(ARGV[0], from: ARGV[2]).run
 end

--- a/lib/mergometer/report.rb
+++ b/lib/mergometer/report.rb
@@ -5,8 +5,9 @@ module Mergometer
   class Report
     require "hirb"
 
-    def initialize(repo)
+    def initialize(repo, **options)
       @repo = repo
+      @from = options[:from] || Time.current.last_week.to_date
     end
 
     def run
@@ -16,7 +17,7 @@ module Mergometer
 
     private
 
-      attr_accessor :repo
+      attr_accessor :repo, :from
 
       def render
         puts Hirb::Helpers::AutoTable.render(
@@ -46,7 +47,7 @@ module Mergometer
       end
 
       def filter
-        "base:master #{repo_query} type:pr is:merged"
+        "base:master #{repo_query} type:pr is:merged created:#{from}..#{Time.current.last_week.end_of_week.to_date}"
       end
 
       def fields_to_preload

--- a/lib/mergometer/reports/contribution_report.rb
+++ b/lib/mergometer/reports/contribution_report.rb
@@ -20,13 +20,6 @@ module Mergometer
 
       private
 
-        def filter
-          [
-            "#{repo_query} type:pr created:#{52.weeks.ago.to_date}..#{26.weeks.ago.to_date}",
-            "#{repo_query} type:pr created:#{26.weeks.ago.to_date}..#{1.week.ago.to_date}"
-          ]
-        end
-
         def data_sets
           grouped_entries.values.flatten.group_by(&:user)
         end

--- a/lib/mergometer/reports/individual_review_report.rb
+++ b/lib/mergometer/reports/individual_review_report.rb
@@ -20,13 +20,6 @@ module Mergometer
 
       private
 
-        def filter
-          [
-            "#{repo_query} type:pr created:#{52.weeks.ago.to_date}..#{26.weeks.ago.to_date}",
-            "#{repo_query} type:pr created:#{26.weeks.ago.to_date}..#{1.week.ago.to_date}"
-          ]
-        end
-
         def fields_to_preload
           %i(reviewers)
         end

--- a/lib/mergometer/reports/pr_trend_report.rb
+++ b/lib/mergometer/reports/pr_trend_report.rb
@@ -40,13 +40,6 @@ module Mergometer
             end
           end
         end
-
-        def filter
-          [
-            "#{repo_query} type:pr created:#{52.weeks.ago.to_date}..#{26.weeks.ago.to_date}",
-            "#{repo_query} type:pr created:#{26.weeks.ago.to_date}..#{1.week.ago.to_date}"
-          ]
-        end
     end
   end
 end

--- a/lib/mergometer/reports/review_report.rb
+++ b/lib/mergometer/reports/review_report.rb
@@ -25,7 +25,7 @@ module Mergometer
         end
 
         def filter
-          "#{repo_query} type:pr created:>=#{1.week.ago.to_date}"
+          "#{repo_query} type:pr created:>=#{from}"
         end
 
         def fields_to_preload

--- a/lib/mergometer/reports/weekly_report.rb
+++ b/lib/mergometer/reports/weekly_report.rb
@@ -19,10 +19,6 @@ module Mergometer
           @_entries ||= build_entries
         end
 
-        def filter
-          "#{repo_query} type:pr created:<=#{Time.current.last_week.end_of_week.to_date}"
-        end
-
         def build_entries
           prs.group_by(&:week).map do |week, weekly_prs|
             WeeklyReportEntry.new(week: week, prs: weekly_prs)


### PR DESCRIPTION
### Usage:
`bin/run #{repo} #{report_type} #{from(optional)}`

default value for `from` -> Beginning of last week

### Questions:
- Which reports should have only merged PRs and which should include all of them? `is:merged`
Thinking of moving this logic to individual PRs, so you could give same set of PRs to all report classes.
- As all reports are grouped by week, should we ignore PRs of current week as this week is not over yet? `created:#{from}..#{last_saturday}`, seems unintuitive to me though, to not include all PRs after `from` date.
- What should be default value for from? I think last week is okay because we will mostly generate report using cron job on weekly basis.

@balvig 