### PR TITLE
Get last week's reviews

### DIFF
--- a/lib/mergometer/reports/review_report.rb
+++ b/lib/mergometer/reports/review_report.rb
@@ -25,7 +25,7 @@ module Mergometer
         end
 
         def filter
-          "#{repo_query} type:pr created:>=#{1.week.ago.to_date}"
+          "#{repo_query} type:pr updated:>=#{1.week.ago.to_date}"
         end
 
         def fields_to_preload


### PR DESCRIPTION
@balvig? Is this okay, I don't think it will really get reviews done last week, but better than before. We need to filter reviews too based on date, to get accurate count, and that is a pain because review api endpoint doesn't have `created_at` or `updated_at`.