### PR TITLE
Add error handling when repo name is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,10 @@ Tech OKR Metrics from GitHub
 ```
 git clone https://github.com/balvig/mergometer.git
 cd mergometer
-OCTOKIT_ACCESS_TOKEN=<token> bin/run report_name github_organization/repo_name
+OCTOKIT_ACCESS_TOKEN=<token> bin/run <report_name> <github_organization/repo_name>
 ```
 
-For currently supported reports, see: `lib/mergometer/reports`
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+For currently supported reports, run: `bin/run` with no arguments.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Tech OKR Metrics from GitHub
 ```
 git clone https://github.com/balvig/mergometer.git
 cd mergometer
-OCTOKIT_ACCESS_TOKEN=<token> bin/run
+OCTOKIT_ACCESS_TOKEN=<token> bin/run report_name github_organization/repo_name
 ```
+
+For currently supported reports, see: `lib/mergometer/reports`
 
 ## Development
 

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -3,25 +3,12 @@ require "octokit"
 
 require "mergometer/version"
 require "mergometer/configuration"
+require "mergometer/runner"
 
 reports_path = File.expand_path("../mergometer/reports/**/*.rb", __FILE__)
 Dir[reports_path].each { |f| require f }
 
 module Mergometer
   Configuration.new(cache_time: 72 * 3600).apply
-
-  begin
-    report_type = Object.const_get("Mergometer::Reports::#{ARGV[0]}")
-  rescue NameError
-    reports = Mergometer::Reports.constants.select { |c| c.to_s.end_with?("Report") }
-    puts "Report not found, must be one of: \n\n" + reports.join("\n")
-    exit
-  end
-
-  if ARGV[1]
-    report_type.new(ARGV[1]).run
-  else
-    puts "Usage: bin/run report_name github_organization/repo_name"
-    exit    
-  end
+  Runner.new(report_name: ARGV[0], repo_name: ARGV[1]).run
 end

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -21,7 +21,7 @@ module Mergometer
   if ARGV[1]
     report_type.new(ARGV[1]).run
   else
-    puts "Usage: bin/run 'ReportName' 'organization/repo_name'" 
+    puts "Usage: bin/run report_name github_organization/repo_name"
     exit    
   end
 end

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -17,5 +17,11 @@ module Mergometer
     puts "Report not found, must be one of: \n\n" + reports.join("\n")
     exit
   end
-  report_type.new(ARGV[1]).run
+
+  if ARGV[1]
+    report_type.new(ARGV[1]).run
+  else
+    puts "Usage: bin/run 'ReportName' 'organization/repo_name'" 
+    exit    
+  end
 end

--- a/lib/mergometer/runner.rb
+++ b/lib/mergometer/runner.rb
@@ -1,0 +1,41 @@
+module Mergometer
+  class Runner
+    def initialize(report_name:, repo_name:)
+      @report_name = report_name
+      @repo_name = repo_name
+    end
+
+    def run
+      report.new(repo_name).run
+    end
+
+    private
+      def report_name
+        @report_name.presence || stop
+      end
+
+      def repo_name
+        @repo_name.presence || stop
+      end
+
+      def report
+        Object.const_get(report_class_name)
+      rescue NameError
+        stop
+      end
+
+      def report_class_name
+        "Mergometer::Reports::#{report_name}"
+      end
+
+      def stop
+        puts "\nUsage: OCTOKIT_ACCESS_TOKEN=<token> bin/run <report_name> <github_org/repo_name>"
+        puts "\nAvailable reports: \n\n" + available_reports.join("\n")
+        exit
+      end
+
+      def available_reports
+        Mergometer::Reports.constants.select { |c| c.to_s.end_with?("Report") }
+      end
+  end
+end


### PR DESCRIPTION
This PR https://github.com/balvig/mergometer/pull/1 is a great addition but errors out with cryptic error message when repo name is not specified:

```
P702:mergometer pawel-rusin$ bin/run ContributionReport
/Users/pawel-rusin/Devel/mergometer/lib/mergometer/report.rb:57:in `repo_query': undefined method `split' for nil:NilClass (NoMethodError)
	from /Users/pawel-rusin/Devel/mergometer/lib/mergometer/reports/contribution_report.rb:25:in `filter'
	from /Users/pawel-rusin/Devel/mergometer/lib/mergometer/report.rb:67:in `fetch_prs'
	from /Users/pawel-rusin/Devel/mergometer/lib/mergometer/report.rb:63:in `prs'
	from /Users/pawel-rusin/Devel/mergometer/lib/mergometer/report.rb:73:in `preload'
	from /Users/pawel-rusin/Devel/mergometer/lib/mergometer/report.rb:13:in `run'
	from lib/mergometer.rb:20:in `<module:Mergometer>'
	from lib/mergometer.rb:10:in `<main>'
P702:mergometer pawel-rusin$ git checkout master
```

To save users some debugging time, I've added more user-friendly error message and updated README a bit.

Please review 🙏 