### PR TITLE
Refactor the CLI, allowing the gem to be loaded without running

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,26 @@ Tech OKR Metrics from GitHub
 
 ## Usage
 
+You can either:
+- Clone this repository.
+- Install the gem.
+
+### Cloning this repository
 ```
 git clone https://github.com/balvig/mergometer.git
 cd mergometer
-OCTOKIT_ACCESS_TOKEN=<token> bin/run <report_name> <github_organization/repo_name>
+bundle
+OCTOKIT_ACCESS_TOKEN=<token> bundle exec exe/mergometer <report_name> <github_organization/repo_name>
 ```
 
-For currently supported reports, run: `bin/run` with no arguments.
+### Installing this gem
+_This will work only after the gem gets published to RubyGems._
+```
+gem install mergometer
+OCTOKIT_ACCESS_TOKEN=<token> mergometer <report_name> <github_organization/repo_name>
+```
+
+For currently supported reports, run `mergometer` with no arguments.
 
 ## Contributing
 

--- a/bin/run
+++ b/bin/run
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-bundle exec ruby lib/mergometer.rb $1 $2

--- a/exe/mergometer
+++ b/exe/mergometer
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "mergometer/cli"
+
+Mergometer::Cli.run(ARGV)

--- a/lib/mergometer.rb
+++ b/lib/mergometer.rb
@@ -3,12 +3,10 @@ require "octokit"
 
 require "mergometer/version"
 require "mergometer/configuration"
-require "mergometer/runner"
 
 reports_path = File.expand_path("../mergometer/reports/**/*.rb", __FILE__)
 Dir[reports_path].each { |f| require f }
 
 module Mergometer
   Configuration.new(cache_time: 72 * 3600).apply
-  Runner.new(report_name: ARGV[0], repo_name: ARGV[1]).run
 end

--- a/lib/mergometer/cli.rb
+++ b/lib/mergometer/cli.rb
@@ -1,8 +1,13 @@
+require "mergometer"
+
 module Mergometer
-  class Runner
-    def initialize(report_name:, repo_name:)
-      @report_name = report_name
-      @repo_name = repo_name
+  class Cli
+    def self.run(*args)
+      new(*args).run
+    end
+
+    def initialize(argv)
+      @argv = argv
     end
 
     def run
@@ -10,12 +15,15 @@ module Mergometer
     end
 
     private
+
+      attr_reader :argv
+
       def report_name
-        @report_name.presence || stop
+        argv[0].presence || stop
       end
 
       def repo_name
-        @repo_name.presence || stop
+        argv[1].presence || stop
       end
 
       def report
@@ -29,7 +37,7 @@ module Mergometer
       end
 
       def stop
-        puts "\nUsage: OCTOKIT_ACCESS_TOKEN=<token> bin/run <report_name> <github_org/repo_name>"
+        puts "\nUsage: OCTOKIT_ACCESS_TOKEN=<token> #{$0} <report_name> <github_org/repo_name>"
         puts "\nAvailable reports: \n\n" + available_reports.join("\n")
         exit
       end


### PR DESCRIPTION
Reviewing @aadityataparia's code [gave me this idea](https://github.com/balvig/mergometer/pull/14#discussion_r195307678).

Thought it would be nice to:
- make the gem usable by Ruby applications.
- expose a `mergometer` executable that users can _just™_ run.

Update to the instructions sums it all:


## Usage

You can either:
- Clone this repository.
- Install the gem.

### Cloning this repository
```
git clone https://github.com/balvig/mergometer.git
cd mergometer
bundle
OCTOKIT_ACCESS_TOKEN=<token> bundle exec exe/mergometer <report_name> <github_organization/repo_name>
```

### Installing this gem
_This will work only after the gem gets published to RubyGems._
```
gem install mergometer
OCTOKIT_ACCESS_TOKEN=<token> mergometer <report_name> <github_organization/repo_name>
```